### PR TITLE
🚧 Remove model deploy step from CI due to #74

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,12 @@ jobs:
           - run:
               name: Deploy server
               command: ./scripts/run_local_server.sh
-          - run:
-              name: Deploy model
-              command: ./scripts/load_kidsfirst.sh
+
+          # TODO - This will fail until we solve the ValueSet pre-expansion
+          # issue https://github.com/kids-first/kf-api-fhir-service/issues/74
+          # - run:
+          #     name: Deploy model
+          #     command: ./scripts/load_kidsfirst.sh
 
           - run:
               name: Test deploy


### PR DESCRIPTION
Workaround for #74 . This does not affect production. The model deploy step in CircleCI pipeline is only part of testing the local developer's docker compose stack.