### PR TITLE
Security Group change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ ecs_service_type_1_standard {
     vcpu_task                  = "4096"
     memory_task                = "8192"
     create_service_discovery   = "1"
-    app_sg_name                = "ElasticMapReduce-Slave-Private-qa-20210122222002663600000001"
+    app_sg_name                = "ElasticMapReduce-Master-Private-qa-20210122222002664300000002"
     additional_container_ports = "9000,9100"
     additional_ssl_cert_domain_name = "*.kidsfirstdrc.org"
     external_domain = "kidsfirstdrc.org"


### PR DESCRIPTION
Description
------------

The kf-clin-etl EMR job fails because CloudMap was set up with an incorrect security group on the container. It should be pointed to ElasticMapReduce-Master-Private-qa-20210122222002664300000002 instead of Slave.