### PR TITLE
👷‍♀️ Transition from Dockerhub to GitHub packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOCKER_HUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKER_HUB_PW: ${{ secrets.DOCKERHUB_PASSWORD }}
+  GITHUB_PAT_SMILECDR: {{ secrets.GH_PAT_SMILECDR }}
+  GITHUB_USERNAME: {{ secrets.GH_USERNAME }}
 
 jobs:
   test-dev-setup:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
+    permissions:
+      packages: read
     steps:
       - name: 👩‍💻 Checkout code
         uses: actions/checkout@v3
@@ -37,6 +39,8 @@ jobs:
   test-local-integration:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
+    permissions:
+      packages: read
     steps:
       - name: 👩‍💻 Checkout code
         uses: actions/checkout@v3
@@ -45,7 +49,7 @@ jobs:
         run: |
           cp env.sample .env
           source .env
-          docker login -u ${{ env.DOCKER_HUB_USERNAME }} -p ${{ env.DOCKER_HUB_PW }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
           docker-compose pull --ignore-pull-failures
           docker-compose up -d
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GITHUB_PAT_SMILECDR: {{ secrets.GH_PAT_SMILECDR }}
-  GITHUB_USERNAME: {{ secrets.GH_USERNAME }}
+  GITHUB_PAT_SMILECDR: ${{ secrets.GH_PAT_SMILECDR }}
+  GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
 
 jobs:
   test-dev-setup:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ how everything works.
 Please make sure you have [Docker](https://docs.docker.com/desktop/) 
 installed on your system and it is running. 
 
+You will also need to do the following in order to access the private docker 
+image on Github packages registry:
+
+1. Create a [Github personal access token (classic)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) with `read:packages` scope
+2. export `GITHUB_PAT_SMILECDR=<your token>`
+3. export `GITHUB_USERNAME=<your github username>`
+4. Request access to the smilecdr image: contact Natasha Singh singn4@chop.edu or Alex Lubneuski lubneuskia@chop.edu 
+
 ### Setup
 ```shell
 ./src/bin/quickstart.sh --delete-volumes
@@ -165,21 +173,6 @@ curl -X POST -H 'Content-Type: application/json' \
 -d '{"client_id": "ingest-study-client","client_secret": "lkhZRex5E58JCjcnIKkLcT4t1Q9dw5OW"}' \
 http://localhost:8081/keycloak-proxy/token
 ```
-
-### 💡 Important Note About Keycloak
-You may notice the instructions to get the access token are different here 
-in the Developer section than the Quickstart secion.
-
-Unfortunately we cannot send requests directly to Keycloak to get access tokens
-since Keycloak will then use "localhost" in the access token's issuer field 
-(ex. `http://localhost:8080/realms/fhir-dev/protocol/openid-connect/token`).
-
-Then when this access token is sent to Smile CDR inside the docker stack, it 
-will fail since Smile CDR inside the docker network does not know what 
-`http://localhost:8080` is. 
-
-To mitigate this we simply send requests to the proxy service which then 
-forwards the request to the Keycloack docker service. 
 
 ### Inspect Token
 You should get back a response that looks like this (access token removed 
@@ -249,32 +242,32 @@ https://releases.smilecdr.com/
 
 ### Upgrading to a New Version
 
-Follow these steps to upgrade to a new version of Smile CDR:
-
+### Steps
 1. Download the docker image tarball from the smilecdr releases site ^
 2. Create a new local image from the tarball
-3. Tag and push the image to the kidsfirstdrc/smilecdr repo on Dockerhub so 
+3. Tag and push the image to the kids-first/smilecdr repo on Github packages so 
 that other developers have access to the image
 4. Tag and push the image to both kf-stridess and include ECRs so
 that future deployments have access to the new version
 5. Update the base image in the Dockerfiles (Dockerfile.includedcc, Dockerfile.kidsfirst_upgrade)
-6. Update the docker-compose.yml file to use the new image
+6. Update the docker-compose.yml file to use the new image tag
 7. Push the changes to Github to trigger the deployment and ensure the new
 image works
 
-There are scripts to help with all of these steps. Here is an example of how 
-to upgrade to version 2023.05.R02:
+Run the following scripts to do steps 2-4. Here is an example of how to upgrade to version 2023.05.R02:
 
 ```shell
 # Step 2
 ./bin/upgrade/new_image.sh ~/Downloads/smilecdr-2023.05.R02-docker.tar.gz 2023.05.R02
 
 # Step 3
-./bin/upgrade/upgrade_dockherhub_image.sh kidsfirstdrc:smilecdr/2023.05.R02
+./bin/upgrade/upgrade_ghcr_image.sh kids-first:smilecdr/2023.05.R02
 
 # Step 4
 ./bin/upgrade/upgrade_ecr_image.sh kf-strides-smile-cdr 2023.05.R02
 ```
+
+
 
 ## 💻 Codebase
 
@@ -347,6 +340,21 @@ time (on docker-compose up)
 
 - Keycloak clients that have been configured with different FHIR roles and 
 consent grants. These get loaded in at deploy time (on docker-compose up)
+
+### 💡 Important Note About Keycloak
+You may notice the instructions to get the access token are different here 
+in the Developer section than the Quickstart secion.
+
+Unfortunately we cannot send requests directly to Keycloak to get access tokens
+since Keycloak will then use "localhost" in the access token's issuer field 
+(ex. `http://localhost:8080/realms/fhir-dev/protocol/openid-connect/token`).
+
+Then when this access token is sent to Smile CDR inside the docker stack, it 
+will fail since Smile CDR inside the docker network does not know what 
+`http://localhost:8080` is. 
+
+To mitigate this we simply send requests to the proxy service which then 
+forwards the request to the Keycloack docker service. 
 
 ## Web App
 - A simple Keycloak proxy that makes it easy to get an access token from 

--- a/bin/upgrade/new_image.sh
+++ b/bin/upgrade/new_image.sh
@@ -9,7 +9,7 @@ START_TIME=$SECONDS
 if [[ -z $1 && -z $2 ]];
 then
     echo "You must supply the path to the docker tar.gz and the image tag to use"
-    echo "Usage: ./bin/$(basename "$0") path/to/tar.gz kidsfirstdrc:smilecdr/2023.05.R02"
+    echo "Usage: ./bin/$(basename "$0") path/to/tar.gz kids-first:smilecdr/2023.05.R02"
     exit 1
 fi
 

--- a/bin/upgrade/pull_ghcr_image.sh
+++ b/bin/upgrade/pull_ghcr_image.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Pull a Smile CDR docker image from the Github packages registry
+
+# ./pull_ghcr_image.sh <docker image tag> <github username>
+
+set -e
+START_TIME=$SECONDS
+
+if [[ -z $GITHUB_PAT_SMILECDR ]];
+then
+    echo "You must have the GITHUB_PAT_SMILECDR environment variable set to "
+    echo "continue. This should contain a Github personal access token (classic)"
+    echo "with the appropriate permissions for reading from the Github package registry"
+    echo "See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic for details"
+fi
+
+
+if [[ -z $1 && -z $2 ]];
+then
+    echo "You must supply the image tag to use and your github username"
+    echo "Usage: ./bin/$(basename "$0") kids-first/smilecdr:2023.05.R02 znatty22"
+    exit 1
+fi
+
+echo "🐳 Docker login to Github package registry ghcr.io"
+echo $GITHUB_PAT_SMILECDR | docker login ghcr.io -u $2 --password-stdin
+
+echo "🐳 Docker pull from Github package registry"
+docker pull "ghcr.io/$1"
+
+ELAPSED=$((( SECONDS - START_TIME ) / 60 ))
+FORMATTED_ELAPSED=$(printf "%.2f" $ELAPSED)
+
+echo "Elapsed time $FORMATTED_ELAPSED minutes"
+

--- a/bin/upgrade/upgrade_ghcr_image.sh
+++ b/bin/upgrade/upgrade_ghcr_image.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Pushes a Smile CDR docker image to the appropriate repo on Github packages
+# registry
+
+# ./bin/upgrade/upgrade_ghcr_image.sh <docker image tag> <github username>
+
+set -e
+START_TIME=$SECONDS
+
+if [[ -z $GITHUB_PAT_SMILECDR ]];
+then
+    echo "You must have the GITHUB_PAT_SMILECDR environment variable set to "
+    echo "continue. This should contain a Github personal access token (classic)"
+    echo "with the appropriate permissions for writing to Github package registry"
+    echo "See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic for details"
+fi
+
+
+if [[ -z $1 && -z $2 ]];
+then
+    echo "You must supply the image tag to use and your github username"
+    echo "Usage: ./bin/$(basename "$0") kids-first/smilecdr:2023.05.R02 znatty22"
+    exit 1
+fi
+
+echo "🏷️ Tagging image with $1"
+docker tag smilecdr:latest "ghcr.io/$1"
+
+echo "🐳 Docker login to Github package registry ghcr.io"
+echo $GITHUB_PAT_SMILECDR | docker login ghcr.io -u $2 --password-stdin
+
+echo "🐳 Docker push to Github package registry"
+docker push "ghcr.io/$1"
+
+ELAPSED=$((( SECONDS - START_TIME ) / 60 ))
+FORMATTED_ELAPSED=$(printf "%.2f" $ELAPSED)
+echo "✅ Created new image. Remember to update docker-compose.yml"
+echo "Elapsed time $FORMATTED_ELAPSED minutes"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.8"
 services:
   smilecdr:
     container_name: smilecdr
-    image: ghcr.io/kidsfirstdrc/smilecdr:2023.05.R02
+    image: ghcr.io/kids-first/smilecdr:2023.05.R02
     env_file:
       - .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.8"
 services:
   smilecdr:
     container_name: smilecdr
-    image: kidsfirstdrc/smilecdr:2023.05.R02
+    image: ghcr.io/kidsfirstdrc/smilecdr:2023.05.R02
     env_file:
       - .env
     ports:

--- a/src/bin/setup_dev_env.sh
+++ b/src/bin/setup_dev_env.sh
@@ -11,8 +11,8 @@ set -e
 
 START_TIME=$SECONDS
 DELETE_VOLUMES=0
-DOCKER_HUB_USERNAME=${DOCKER_HUB_USERNAME}
-DOCKER_HUB_PW=${DOCKER_HUB_PW}
+GITHUB_USERNAME=${GITHUB_USERNAME}
+GITHUB_PAT_SMILECDR=${GITHUB_PAT_SMILECDR}
 
 while [ -n "$1" ]; do 
 	case "$1" in
@@ -51,16 +51,20 @@ else
     docker-compose down
 fi
 
-# Check docker hub creds 
-if [[ -z $DOCKER_HUB_USERNAME ]] || [[ -z $DOCKER_HUB_PW ]]
+# Check github packages registry creds 
+if [[ -z $GITHUB_USERNAME ]] || [[ -z $GITHUB_PAT_SMILECDR ]]
 then
-    echo "🔐 You need the Kids First DRC docker hub credentials to continue" 
-    echo "Please contact the Github repo admins: natasha@d3b.center or meenchulkim@d3b.center" 
+    echo "🔐 You must have the GITHUB_USERNAME and GITHUB_PAT_SMILECDR environment variable set to "
+    echo "continue. GITHUB_PAT_SMILECDR should contain a Github personal access token (classic)"
+    echo "with the appropriate permissions for reading from the Github package registry"
+    echo "See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic for details"
+    echo "🛂 You will also need to be a collaborator on the repo in GHCR"
+    echo "Please contact Natasha Singh singn4@chop.edu or Alex Lubneuski lubneuskia@chop.edu"
     exit 1
 fi
 
-echo "Logging into Docker Hub ..."
-echo "$DOCKER_HUB_PW" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+echo "Logging into Github packages registry ..."
+echo "$GITHUB_PAT_SMILECDR" | docker login ghcr.io -u "$GITHUB_USERNAME" --password-stdin
 
 sleep 10
 

--- a/src/bin/setup_dev_env.sh
+++ b/src/bin/setup_dev_env.sh
@@ -54,10 +54,12 @@ fi
 # Check github packages registry creds 
 if [[ -z $GITHUB_USERNAME ]] || [[ -z $GITHUB_PAT_SMILECDR ]]
 then
-    echo "🔐 You must have the GITHUB_USERNAME and GITHUB_PAT_SMILECDR environment variable set to "
-    echo "continue. GITHUB_PAT_SMILECDR should contain a Github personal access token (classic)"
+    echo "🔐 You must have the GITHUB_USERNAME and GITHUB_PAT_SMILECDR environment variable set to continue. "
+    echo "GITHUB_USERNAME should be set to your github username and GITHUB_PAT_SMILECDR should contain a Github personal access token (classic)"
     echo "with the appropriate permissions for reading from the Github package registry"
+
     echo "See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic for details"
+
     echo "🛂 You will also need to be a collaborator on the repo in GHCR"
     echo "Please contact Natasha Singh singn4@chop.edu or Alex Lubneuski lubneuskia@chop.edu"
     exit 1


### PR DESCRIPTION
Closes #144 

We need to move away from Dockerhub since you have to pay for collaborators on private repos. Developers will now have to follow these steps to get access to the smilecdr image on Github packages repo:

1. Create a Github personal access token (classic) and set in env
2. Set Github username in env
3. Ask to be added as a collaborator on the ghcr.io/kids-first/smilecdr repo
4. Run src/bin/quickstart.sh as usual to startup the docker stack